### PR TITLE
Fix AWS region in ecs deployment

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,15 +1,15 @@
 config {
-  module = false
+  call_module_type = "none"
   disabled_by_default = false
   variables = [
-    "create_eks=true",
+    # "create_eks=true",
     "create_cdn=true"
     ]
 }
 
 plugin "aws" {
   enabled = true
-  version = "0.21.2"
+  version = "0.38.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/modules/ecs/deployment.tf
+++ b/modules/ecs/deployment.tf
@@ -108,6 +108,10 @@ module "container_definition" {
       value = var.challenge_bucket
     },
     {
+      name  = "AWS_S3_REGION"
+      value = data.aws_region.current.name
+    },
+    {
       name  = "ACCESS_LOG"
       value = local.access_log
     },


### PR DESCRIPTION
If you deploy this in a non default region, ctfd can't get the challenge files in the challenge bucket. Since sigv4 is being used, the region has to be correct. Setting the region in the container's environment fixes the issue.